### PR TITLE
feat(bigtable): fix gRPC metrics export and Monarch ingestion

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -128,7 +128,9 @@ void Benchmark::DeleteTable() {
 }
 
 Table Benchmark::MakeTable(Options connection_opts) const {
-  auto connection_options = MergeOptions(std::move(connection_opts), opts_);
+  auto connection_options =
+      MergeOptions(std::move(connection_opts), opts_)
+          .set<bigtable::MetricsPeriodOption>(std::chrono::seconds(5));
   auto table_opts = Options{}.set<AppProfileIdOption>(options_.app_profile_id);
   return Table(
       MakeDataConnection({InstanceResource(Project(options_.project_id),

--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -214,8 +214,7 @@ std::shared_ptr<DataConnection> MakeDataConnection(Options options) {
     std::string client_uid = google::cloud::internal::Sample(
         gen, 16, "abcdefghijklmnopqrstuvwxyz0123456789");
 #ifdef GOOGLE_CLOUD_CPP_BIGTABLE_WITH_GRPC_OTEL_METRICS
-    if (bigtable::internal::IsDirectPath(options) &&
-        options.has<bigtable_internal::InstanceChannelAffinityOption>() &&
+    if (options.has<bigtable_internal::InstanceChannelAffinityOption>() &&
         options.get<experimental::DirectPathMetricsModeOption>() ==
             experimental::DirectPathMetricsMode::kEnabled) {
       bigtable_internal::EnableGrpcMetrics(metric_service_connection, options,

--- a/google/cloud/bigtable/internal/grpc_metrics_exporter.cc
+++ b/google/cloud/bigtable/internal/grpc_metrics_exporter.cc
@@ -25,6 +25,7 @@
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include <grpcpp/ext/otel_plugin.h>
 #include <grpcpp/grpcpp.h>
@@ -203,7 +204,7 @@ MonitoredResourceResult MakeMonitoredResource(
     Options const& options, std::string const& client_uid) {
   namespace sc = ::opentelemetry::semconv;
   google::api::MonitoredResource resource;
-  resource.set_type("bigtable.googleapis.com/Client");
+  resource.set_type("bigtable_client");
   auto& labels = *resource.mutable_labels();
   auto const& attributes = pda.attributes.GetAttributes();
   auto get_attr = [&](std::string const& key) {
@@ -240,8 +241,18 @@ MonitoredResourceResult MakeMonitoredResource(
     project_id = by_name(sc::cloud::kCloudAccountId);
   }
 
+  auto instance_id = get_attr("instance");
+  if (instance_id.empty() &&
+      options.has<bigtable_internal::InstanceChannelAffinityOption>()) {
+    auto const& instances =
+        options.get<bigtable_internal::InstanceChannelAffinityOption>();
+    if (!instances.empty()) {
+      instance_id = instances[0].instance_id();
+    }
+  }
+
   labels["project_id"] = project_id;
-  labels["instance"] = get_attr("instance");
+  labels["instance"] = instance_id;
   labels["app_profile"] = options.get<bigtable::AppProfileIdOption>();
   labels["client_name"] = "cpp.Bigtable/" + bigtable::version_string();
   labels["uuid"] = client_uid;
@@ -253,13 +264,23 @@ MonitoredResourceResult MakeMonitoredResource(
   if (!client_project.empty()) {
     labels["client_project"] = client_project;
   }
-  labels["location"] = by_name(sc::cloud::kCloudAvailabilityZone,
-                               by_name(sc::cloud::kCloudRegion, "global"));
+  auto region = by_name(sc::cloud::kCloudRegion);
+  if (region.empty()) {
+    region = by_name(sc::cloud::kCloudAvailabilityZone);
+    auto pos = region.find_last_of('-');
+    if (pos != std::string::npos && pos + 2 == region.size()) {
+      region.resize(pos);
+    }
+  }
+  if (region.empty()) {
+    region = "global";
+  }
+  labels["region"] = std::move(region);
   labels["cloud_platform"] = by_name(sc::cloud::kCloudPlatform, "unknown");
   labels["host_id"] = by_name("faas.id", by_name(sc::host::kHostId, "unknown"));
   auto hostname = by_name(sc::host::kHostName);
   if (!hostname.empty()) {
-    labels["hostname"] = hostname;
+    labels["host_name"] = hostname;
   }
 
   return MonitoredResourceResult{std::move(project_id), std::move(resource)};
@@ -283,14 +304,41 @@ void EnableGrpcMetrics(
                               std::move(res.resource));
       };
 
-  std::set<std::string> excluded_labels{"project_id", "instance"};
+  std::set<std::string> excluded_labels{
+      "project_id",
+      "instance",
+      "app_profile",
+      "client_project",
+      "cloud_platform",
+      "region",
+      "client_region",
+      "host_id",
+      "host_name",
+      "client_name",
+      "uuid",
+      "service_name",
+      "service_namespace",
+      "service_instance_id",
+      "service.name",
+      "service.namespace",
+      "service.instance.id",
+  };
   auto resource_filter_fn =
       [excluded_labels = std::move(excluded_labels)](std::string const& key) {
         return internal::Contains(excluded_labels, key);
       };
 
+  auto constexpr kBigtableMetricNamePath =
+      "bigtable.googleapis.com/internal/client/";
+  auto exporter_options = options;
+  exporter_options.set<otel::ServiceTimeSeriesOption>(true)
+      .set<otel::MetricNameFormatterOption>([=](auto name) {
+        return kBigtableMetricNamePath +
+               absl::StrReplaceAll(name, {{".", "/"}});
+      });
+
   auto exporter = otel_internal::MakeMonitoringExporter(
-      dynamic_resource_fn, resource_filter_fn, conn, options);
+      dynamic_resource_fn, resource_filter_fn, conn, exporter_options);
 
   auto reader_options =
       opentelemetry::sdk::metrics::PeriodicExportingMetricReaderOptions{};
@@ -317,6 +365,12 @@ void EnableGrpcMetrics(
       absl::string_view{"grpc.subchannel.connection_attempts_failed"},
       absl::string_view{"grpc.subchannel.open_connections"},
   };
+  auto const disable_metrics = std::vector<absl::string_view>{
+      absl::string_view{
+          "grpc.client.attempt.sent_total_compressed_message_size"},
+      absl::string_view{
+          "grpc.client.attempt.rcvd_total_compressed_message_size"},
+  };
   auto scope_filter =
       [authority = std::move(authority)](
           grpc::OpenTelemetryPluginBuilder::ChannelScope const& scope) {
@@ -330,6 +384,7 @@ void EnableGrpcMetrics(
       grpc::OpenTelemetryPluginBuilder()
           .SetMeterProvider(provider)
           .EnableMetrics(metrics)
+          .DisableMetrics(disable_metrics)
           .SetGenericMethodAttributeFilter([](absl::string_view target) {
             return absl::StartsWith(target, "google.bigtable.v2");
           })

--- a/google/cloud/bigtable/internal/grpc_metrics_exporter_test.cc
+++ b/google/cloud/bigtable/internal/grpc_metrics_exporter_test.cc
@@ -198,7 +198,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResource) {
   EXPECT_THAT(result.project_id, Eq("test-project"));
 
   auto const& resource = result.resource;
-  EXPECT_THAT(resource.type(), Eq("bigtable.googleapis.com/Client"));
+  EXPECT_THAT(resource.type(), Eq("bigtable_client"));
 
   auto const& labels = resource.labels();
   EXPECT_THAT(labels.at("project_id"), Eq("test-project"));
@@ -208,7 +208,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResource) {
   EXPECT_THAT(labels.at("client_name"),
               Eq("cpp.Bigtable/" + bigtable::version_string()));
   EXPECT_THAT(labels.at("uuid"), Eq("test-client-uid"));
-  EXPECT_THAT(labels.at("location"), Eq("global"));
+  EXPECT_THAT(labels.at("region"), Eq("global"));
   EXPECT_THAT(labels.at("cloud_platform"), Eq("unknown"));
   EXPECT_THAT(labels.at("host_id"), Eq("unknown"));
 }
@@ -224,7 +224,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourceMissingAttributes) {
   EXPECT_THAT(result.project_id, Eq(""));
 
   auto const& resource = result.resource;
-  EXPECT_THAT(resource.type(), Eq("bigtable.googleapis.com/Client"));
+  EXPECT_THAT(resource.type(), Eq("bigtable_client"));
 
   auto const& labels = resource.labels();
   EXPECT_THAT(labels.at("project_id"), Eq(""));
@@ -233,7 +233,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourceMissingAttributes) {
   EXPECT_THAT(labels.at("client_name"),
               Eq("cpp.Bigtable/" + bigtable::version_string()));
   EXPECT_THAT(labels.at("uuid"), Eq("test-client-uid"));
-  EXPECT_THAT(labels.at("location"), Eq("global"));
+  EXPECT_THAT(labels.at("region"), Eq("global"));
   EXPECT_THAT(labels.at("cloud_platform"), Eq("unknown"));
   EXPECT_THAT(labels.at("host_id"), Eq("unknown"));
 }
@@ -251,7 +251,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourcePartialAttributes) {
   EXPECT_THAT(result.project_id, Eq("test-project"));
 
   auto const& resource = result.resource;
-  EXPECT_THAT(resource.type(), Eq("bigtable.googleapis.com/Client"));
+  EXPECT_THAT(resource.type(), Eq("bigtable_client"));
 
   auto const& labels = resource.labels();
   EXPECT_THAT(labels.at("project_id"), Eq("test-project"));
@@ -261,7 +261,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourcePartialAttributes) {
   EXPECT_THAT(labels.at("client_name"),
               Eq("cpp.Bigtable/" + bigtable::version_string()));
   EXPECT_THAT(labels.at("uuid"), Eq("test-client-uid"));
-  EXPECT_THAT(labels.at("location"), Eq("global"));
+  EXPECT_THAT(labels.at("region"), Eq("global"));
   EXPECT_THAT(labels.at("cloud_platform"), Eq("unknown"));
   EXPECT_THAT(labels.at("host_id"), Eq("unknown"));
 }
@@ -282,7 +282,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourceExtraAttributes) {
   EXPECT_THAT(result.project_id, Eq("test-project"));
 
   auto const& resource = result.resource;
-  EXPECT_THAT(resource.type(), Eq("bigtable.googleapis.com/Client"));
+  EXPECT_THAT(resource.type(), Eq("bigtable_client"));
 
   auto const& labels = resource.labels();
   EXPECT_THAT(labels.size(), Eq(9));
@@ -293,7 +293,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourceExtraAttributes) {
   EXPECT_THAT(labels.at("client_name"),
               Eq("cpp.Bigtable/" + bigtable::version_string()));
   EXPECT_THAT(labels.at("uuid"), Eq("test-client-uid"));
-  EXPECT_THAT(labels.at("location"), Eq("global"));
+  EXPECT_THAT(labels.at("region"), Eq("global"));
   EXPECT_THAT(labels.at("cloud_platform"), Eq("unknown"));
   EXPECT_THAT(labels.at("host_id"), Eq("unknown"));
   EXPECT_THAT(labels.find("grpc.method"), Eq(labels.end()));
@@ -325,7 +325,7 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourceWithDetectedResource) {
   EXPECT_THAT(result.project_id, Eq("test-project"));
 
   auto const& resource = result.resource;
-  EXPECT_THAT(resource.type(), Eq("bigtable.googleapis.com/Client"));
+  EXPECT_THAT(resource.type(), Eq("bigtable_client"));
 
   auto const& labels = resource.labels();
   EXPECT_THAT(labels.at("project_id"), Eq("test-project"));
@@ -335,10 +335,10 @@ TEST(GrpcMetricsExporterTest, MakeMonitoredResourceWithDetectedResource) {
   EXPECT_THAT(labels.at("client_name"),
               Eq("cpp.Bigtable/" + bigtable::version_string()));
   EXPECT_THAT(labels.at("uuid"), Eq("test-client-uid"));
-  EXPECT_THAT(labels.at("location"), Eq("us-central1-a"));
+  EXPECT_THAT(labels.at("region"), Eq("us-central1"));
   EXPECT_THAT(labels.at("cloud_platform"), Eq("gcp_compute_engine"));
   EXPECT_THAT(labels.at("host_id"), Eq("123456789"));
-  EXPECT_THAT(labels.at("hostname"), Eq("test-vm-host"));
+  EXPECT_THAT(labels.at("host_name"), Eq("test-vm-host"));
 }
 
 TEST(GrpcMetricsExporterTest, MakeLatencyHistogramBoundaries) {


### PR DESCRIPTION
Fix multiple client-side schema and formatting issues in the gRPC OpenTelemetry exporter to enable successful metric ingestion into Google Cloud Monitoring / Monarch (cloud_prod):

- Resource Type: Updated monitored resource type from "bigtable.googleapis.com/Client" to "bigtable_client" to align with GCM resource_types.gcl definitions.
- Instance ID Resolution: Added fallback to extract instance_id and project_id from InstanceChannelAffinityOption when not present in gRPC point attributes.
- Metric Name Formatting: Configured MetricNameFormatterOption to prepend "bigtable.googleapis.com/internal/client/" and convert dot separators to slashes.
- Service Time Series: Enabled ServiceTimeSeriesOption(true) to route internal client metric exports via CreateServiceTimeSeries.
- Region & Zone Normalization: Renamed label key from "location" to "region" and added GCP zone suffix stripping (e.g. "us-east1-c" to "us-east1") for proper Monarch regional aggregation.
- Label Filtering: Expanded excluded_labels to filter out SDK auto-injected attributes (service_name, service_namespace, and monitored resource keys) that caused GCM ingestion rejections.
- Hostname Key: Corrected label key from "hostname" to "host_name".
- Disabled Extra Metrics: Disabled sent/rcvd message size metrics via DisableMetrics to reduce metric cardinality.
- Tests & Benchmarks: Updated unit tests and configured 5s metric period in benchmarks for responsive testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scotthart/google-cloud-cpp/2)
<!-- Reviewable:end -->
